### PR TITLE
Cargo.toml: authentification -> authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@
 name = "pam"
 version = "0.7.0"
 authors = ["Florian Wilkens <gh@1wilkens.org>"]
-description = "Safe Rust wrappers for PAM authentification"
+description = "Safe Rust wrappers for PAM authentication"
 license = "MIT OR Apache-2.0"
 categories = ["authentication"]
 


### PR DESCRIPTION
While the former is an English word, the latter is the usual choice, and also what the 'A' in PAM stands for.