### PR TITLE
lib.rs: Make PamReturnCode field in PamError public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Changed
+- Make PamReturnCode field in PamError public to allow matching on it
+
+### Changed
 - Move CI to azure pipelines (and remove `.travis.yml`)
 
 ### Fixed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ use std::ffi::{CStr, CString};
 
 pub use crate::authenticator::*;
 
-pub struct PamError(PamReturnCode);
+pub struct PamError(pub PamReturnCode);
 pub type PamResult<T> = std::result::Result<T, PamError>;
 
 impl std::fmt::Debug for PamError {


### PR DESCRIPTION
The return code field in the PamError type isn't public. This means library users can't match on the specific error code.