### PR TITLE
Changes for non-Linux PAM systems

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -99,7 +99,7 @@ impl<'a, C: conv::Conversation> Client<'a, C> {
             return Err(PamReturnCode::Perm_Denied.into());
         }
 
-        self.last_code = setcred(self.handle, PamFlag::Establish_Cred);
+        self.last_code = setcred(self.handle, PamSetCredFlag::Establish_Cred);
         if self.last_code != PamReturnCode::Success {
             return self.reset();
         }
@@ -110,7 +110,7 @@ impl<'a, C: conv::Conversation> Client<'a, C> {
         }
 
         // Follow openSSH and call pam_setcred before and after open_session
-        self.last_code = setcred(self.handle, PamFlag::Reinitialize_Cred);
+        self.last_code = setcred(self.handle, PamSetCredFlag::Reinitialize_Cred);
         if self.last_code != PamReturnCode::Success {
             return self.reset();
         }
@@ -168,7 +168,7 @@ impl<'a, C: conv::Conversation> Client<'a, C> {
 
     // Utility function to reset the pam handle in case of intermediate errors
     fn reset(&mut self) -> PamResult<()> {
-        setcred(self.handle, PamFlag::Delete_Cred);
+        setcred(self.handle, PamSetCredFlag::Delete_Cred);
         self.is_authenticated = false;
         Err(From::from(self.last_code))
     }
@@ -179,7 +179,7 @@ impl<'a, C: conv::Conversation> Drop for Client<'a, C> {
         if self.has_open_session && self.close_on_drop {
             close_session(self.handle, false);
         }
-        let code = setcred(self.handle, PamFlag::Delete_Cred);
+        let code = setcred(self.handle, PamSetCredFlag::Delete_Cred);
         end(self.handle, code);
     }
 }

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -115,20 +115,9 @@ impl std::fmt::Display for PamReturnCode {
     }
 }
 
-/// The Linux-PAM flags
+/// PAM flags for pam_setcred
 #[pam_enum]
-pub enum PamFlag {
-    /// Default value, if no specific flags should be passed
-    None = 0,
-
-    /// Authentication service should not generate any messages
-    Silent,
-
-    /// The authentication service should return AUTH_ERROR
-    /// if the user has a null authentication token
-    /// (used by pam_authenticate{,_secondary}())
-    Disallow_Null_AuthTok,
-
+pub enum PamSetCredFlag {
     /// Set user credentials for an authentication service
     /// (used for pam_setcred())
     Establish_Cred,
@@ -144,6 +133,45 @@ pub enum PamFlag {
     /// Extend lifetime of user credentials
     /// (used for pam_setcred())
     Refresh_Cred,
+}
+
+impl std::fmt::Display for PamSetCredFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(&format!("{:?} ({})", self, *self as i32))
+    }
+}
+
+/// PAM flags for pam_authenticate
+#[pam_enum]
+pub enum PamAuthenticateFlag {
+    /// Default value, if no specific flags should be passed
+    None = 0,
+
+    /// The authentication service should return AUTH_ERROR
+    /// if the user has a null authentication token
+    /// (used by pam_authenticate{,_secondary}())
+    Disallow_Null_AuthTok,
+}
+
+impl std::fmt::Display for PamAuthenticateFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(&format!("{:?} ({})", self, *self as i32))
+    }
+}
+
+/// PAM flags for pam_ch_authtok and pam_sm_chauthtok
+#[pam_enum]
+pub enum PamAuthTokFlag {
+    /// Default value, if no specific flags should be passed
+    None = 0,
+
+    /// The following two flags are for use across the Linux-PAM/module
+    /// interface only. The Application is not permitted to use these
+    /// tokens.
+    ///
+    /// The password service should only perform preliminary checks.  No
+    /// passwords should be updated.
+    Prelim_Check,
 
     /// The password service should only update those passwords that have aged.
     /// If this flag is not passed, the password service should update all passwords.
@@ -153,14 +181,22 @@ pub enum PamFlag {
     /// The password service should update passwords Note: PAM_PRELIM_CHECK
     /// and PAM_UPDATE_AUTHTOK cannot both be set simultaneously!
     Update_AuthTok,
+}
 
-    /// The following two flags are for use across the Linux-PAM/module
-    /// interface only. The Application is not permitted to use these
-    /// tokens.
-    ///
-    /// The password service should only perform preliminary checks.  No
-    /// passwords should be updated.
-    Prelim_Check,
+impl std::fmt::Display for PamAuthTokFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        f.write_str(&format!("{:?} ({})", self, *self as i32))
+    }
+}
+
+/// The general PAM flags
+#[pam_enum]
+pub enum PamFlag {
+    /// Default value, if no specific flags should be passed
+    None = 0,
+
+    /// Authentication service should not generate any messages
+    Silent,
 }
 
 impl std::fmt::Display for PamFlag {

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -16,7 +16,7 @@ pub use misc::*;
 /* ------------------------ <security/pam_appl.h> -------------------------- */
 #[cfg(feature = "client")]
 mod appl {
-    use crate::{PamFlag, PamHandle, PamResult, PamReturnCode};
+    use crate::{PamFlag, PamHandle, PamResult, PamReturnCode, PamSetCredFlag};
     use libc::c_int;
     use pam_sys as ffi;
     use std::ffi::CString;
@@ -79,7 +79,7 @@ mod appl {
     ///
     /// Valid `PamFlag`s: Silent, {Establish,Delete,Reinitialize,Refresh}_Cred
     #[inline]
-    pub fn setcred(handle: &mut PamHandle, flags: PamFlag) -> PamReturnCode {
+    pub fn setcred(handle: &mut PamHandle, flags: PamSetCredFlag) -> PamReturnCode {
         unsafe { ffi::pam_setcred(handle, flags as c_int) }.into()
     }
 


### PR DESCRIPTION
The XSSO preliminary specification has duplicate values for some
flag constants used with different functions

To accommodate systems that follow the specified values for those constants,
separate the flag enums into their use-cases

Depends on [pam-sys/#16](https://github.com/1wilkens/pam-sys/pull/16)