### PR TITLE
Fix env module

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,7 +1,7 @@
 //! Authentication related structure and functions
 use std::env;
 
-use crate::{conv, enums::*, functions::*, types::*};
+use crate::{conv, enums::*, functions::*, types::*, env::*};
 
 /// Main struct to authenticate a user
 ///
@@ -123,6 +123,15 @@ impl<'a, C: conv::Conversation> Client<'a, C> {
     // Currently always called from Client.open_session()
     fn initialize_environment(&mut self) -> PamResult<()> {
         use users::os::unix::UserExt;
+
+
+        // Set PAM environment in the local process
+        if let Some(mut env_list) = get_pam_env(self.handle) {
+            let env = env_list.to_vec();
+            for (key, value) in env {
+                env::set_var(&key, &value);
+            }
+        }
 
         let user = users::get_user_by_name(self.conversation.username()).unwrap_or_else(|| {
             panic!(

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,14 +1,17 @@
 use libc::c_char;
-use pam_sys::{getenvlist, raw, PamHandle};
+use crate::types::*;
+use pam_sys as raw;
 
 use std::ffi::CStr;
 
 pub struct PamEnvList {
-    ptr: *const *const c_char,
+    ptr: *mut *mut c_char,
 }
 
 pub fn get_pam_env(handle: &mut PamHandle) -> Option<PamEnvList> {
-    let env = getenvlist(handle);
+    let env = unsafe {
+        raw::pam_getenvlist(handle)
+	};
     if !env.is_null() {
         Some(PamEnvList { ptr: env })
     } else {
@@ -22,7 +25,7 @@ impl PamEnvList {
 
         let mut idx = 0;
         loop {
-            let env_ptr: *const *const c_char = unsafe { self.ptr.offset(idx) };
+            let env_ptr: *mut *mut c_char = unsafe { self.ptr.offset(idx) };
             if unsafe { !(*env_ptr).is_null() } {
                 idx += 1;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ mod conv;
 mod enums;
 mod functions;
 mod types;
+mod env;
 
 pub use crate::{enums::*, functions::*, types::*};
 


### PR DESCRIPTION
The `env` module seems to be broken at the moment.
* the PR fixes the env module and adds it to the create namespace
* the `get_pam_env` is done on environment initialization again (as it was in 0.7.0). If not called, it breaks sub modules environment update. For example, if you have a kerberos configuration, the module sets the KRB5CCNAME which may be used in the inherited environment.
 