### PR TITLE
Make PasswordConv public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Add Client::{change_authentication_token,get_user}
 
 ### Changed
+- **Possibly breaking**: make `conv::PasswordConv` public
 - Change `Authenticator::get_handler` to `Authenticator::handler_mut` and add `Authenticator::handler` for immutable access to the handler
 - Move CI to azure pipelines (and remove `.travis.yml`)
 - Make `PamReturnCode` field in `PamError` public to allow matching on it

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,10 @@ pub mod client;
 #[cfg(feature = "module")]
 pub mod module;
 
-pub use crate::{conv::Conversation, enums::*};
+pub use crate::{
+    conv::{Conversation, PasswordConv},
+    enums::*,
+};
 
 #[cfg(feature = "client")]
 pub use client::Client;


### PR DESCRIPTION
This will allow developers to create encapsulating structs without being forced to reimplement PasswordConv.

My use case: in my display manager, I instantiate a [PAM client](https://git.sr.ht/~goorzhel/rstdm/tree/08bf2e3c/item/src/pam.rs#L12) while [logging the user in](https://git.sr.ht/~goorzhel/rstdm/tree/08bf2e3c/item/src/auth.rs#L42) and need to [hold on to it](https://git.sr.ht/~goorzhel/rstdm/tree/08bf2e3c/item/src/main.rs#L53) for the lifetime of `main()`. The wrapper struct also allows me the crucial ability to implement arbitrary methods upon the client, and hence [traits](https://git.sr.ht/~goorzhel/rstdm/tree/08bf2e3c/item/src/pam.rs#L24).
