### PR TITLE
Fix the build on FreeBSD

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ client = ["uzers"]
 module = []
 
 [dependencies]
-pam-macros = "=0.0.3"
+pam-macros = { version = "=0.0.3", path = "macros" }
 libc    = "^0.2"
 pam-sys = "1.0.0-alpha5"
 memchr = "2.5.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -92,7 +92,7 @@ fn build_impl_block(
             } else {
                 // otherwise, fallback to pam_sys
                 // FIXME: This guard should not be necessary
-                parse_quote!(x if x == pam_sys::#id => #enum_name::#v_id,)
+                parse_quote!(x if x == pam_sys::#id.try_into().unwrap() => #enum_name::#v_id,)
             }
         })
         .collect();
@@ -100,6 +100,8 @@ fn build_impl_block(
     parse_quote! {
         impl std::convert::From<i32> for #enum_name {
             fn from(value: i32) -> Self {
+                use ::std::convert::TryInto;
+
                 match value {
                     #(#arms)*
                     _ => #enum_name::#default

--- a/src/enums.rs
+++ b/src/enums.rs
@@ -103,12 +103,6 @@ pub enum PamReturnCode {
     /// Bad item passed to pam_*_item()
     Bad_Item,
 
-    /// conversation function is event driven and data is not available yet
-    Conv_Again,
-
-    /// please call this function again to complete authentication stack.
-    /// Before calling again as isize, verify that conversation is completed
-    Incomplete,
 }
 
 impl std::fmt::Display for PamReturnCode {
@@ -126,11 +120,6 @@ pub enum PamFlag {
     /// Authentication service should not generate any messages
     Silent,
 
-    /// The authentication service should return AUTH_ERROR
-    /// if the user has a null authentication token
-    /// (used by pam_authenticate{,_secondary}())
-    Disallow_Null_AuthTok,
-
     /// Set user credentials for an authentication service
     /// (used for pam_setcred())
     Establish_Cred,
@@ -146,23 +135,6 @@ pub enum PamFlag {
     /// Extend lifetime of user credentials
     /// (used for pam_setcred())
     Refresh_Cred,
-
-    /// The password service should only update those passwords that have aged.
-    /// If this flag is not passed, the password service should update all passwords.
-    /// (used by pam_chauthtok)
-    Change_Expired_AuthTok,
-
-    /// The password service should update passwords Note: PAM_PRELIM_CHECK
-    /// and PAM_UPDATE_AUTHTOK cannot both be set simultaneously!
-    Update_AuthTok,
-
-    /// The following two flags are for use across the Linux-PAM/module
-    /// interface only. The Application is not permitted to use these
-    /// tokens.
-    ///
-    /// The password service should only perform preliminary checks.  No
-    /// passwords should be updated.
-    Prelim_Check,
 }
 
 impl std::fmt::Display for PamFlag {
@@ -204,18 +176,6 @@ pub enum PamItemType {
 
     /// the prompt for getting a username Linux-PAM extensions
     User_Prompt,
-
-    /// app supplied function to override failure delays
-    Fail_Delay,
-
-    /// X display name
-    XDisplay,
-
-    /// X server authentication data
-    XAuthData,
-
-    /// The type for pam_get_authtok
-    AuthTok_Type,
 }
 
 impl std::fmt::Display for PamItemType {

--- a/src/env.rs
+++ b/src/env.rs
@@ -68,10 +68,12 @@ fn drop_env_list(ptr: *const *const c_char) {
 #[cfg(not(target_os = "linux"))]
 fn drop_env_list(ptr: *const *const c_char) {
     // FIXME: verify this
-    let mut cur = *ptr;
-    while !ptr.is_null() {
-        unsafe { free(ptr) };
-        ptr = ptr.add(1);
+    unsafe {
+        let mut cur = *ptr;
+        while !cur.is_null() {
+            libc::free(cur as *mut libc::c_void);
+            cur = cur.add(1);
+        }
+        libc::free(ptr as *mut libc::c_void);
     }
-    unsafe { free(ptr) };
 }

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -168,7 +168,9 @@ mod types {
     #[inline]
     pub fn putenv(handle: &mut PamHandle, name_value: &str) -> PamResult<()> {
         if let Ok(name_value) = CString::new(name_value) {
-            match unsafe { ffi::pam_putenv(handle, name_value.as_ptr()) }.into() {
+            use std::convert::TryFrom;
+
+            match i32::try_from(unsafe { ffi::pam_putenv(handle, name_value.as_ptr()) }).unwrap().into() {
                 PamReturnCode::Success => Ok(()),
                 err => Err(err.into()),
             }


### PR DESCRIPTION
* some pam_sys constants are u32 on FreeBSD instead of i32.
* The CONV_AGAIN and INCOMPLETE flags don't exist on FreeBSD, and weren't used in this crate.  Remove them.
* The Fail_Delay, XDisplay, XAuthData, and AuthTok_Type pam items types don't exist on FreeBSD, and aren't used in this crate, so remove them.
* The Disallow_Null_AuthTok and PrelimCheck pam flags have the same value on FreeBSD as Establish_Cred.  But they aren't actually used, so just remove them.
* The Update_AuthTok pam flag has the same value on FreeBSD as Establish_Cred. But it isn't actually used, so just remove it.
* The Change_Expired_AuthTok pam flag has the same value on FreeBSD as Reinitialize_Cred.  But it isn't actually used, so just remove it.
* Fix the drop_env_list function, which never worked (or even compiled) on non-Linux.

Fixes #42